### PR TITLE
fix #4 Add errorMap extension with class type and predicate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,8 @@ configure(rootProject)  { project ->
 
 	//NB: stdlib version is defined by the kotlin jvm plugin's version
 	optional 'org.jetbrains.kotlin:kotlin-stdlib'
+	  testCompile 'org.jetbrains.kotlin:kotlin-reflect:1.3.50'
+
 
 	testCompile 'junit:junit:4.12'
 	testCompile 'org.assertj:assertj-core:3.12.2'

--- a/src/test/kotlin/reactor/kotlin/core/publisher/MonoExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/core/publisher/MonoExtensionsTests.kt
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Operators
+import reactor.core.publisher.onErrorMap
 import reactor.kotlin.test.test
 import reactor.kotlin.test.verifyError
 import reactor.test.StepVerifier
@@ -248,6 +249,22 @@ class MonoExtensionsTests {
         StepVerifier.create(listOf("foo1", "foo2", "foo3").map { it.toMono() }.zip { it.joinToString() })
                 .expectNext("foo1, foo2, foo3")
                 .verifyComplete()
+    }
+
+    @Test
+    fun `onErrorMap with Kclass and Predicate matches`() {
+        StepVerifier.create(IOException("file not found")
+                .toMono<Any>()
+                .onErrorMap(IOException::class, { it.message == "file not found" }, { IllegalStateException("sa") }))
+                .verifyError<IllegalStateException>()
+    }
+
+    @Test
+    fun `onErrorMap with Kclass and Predicate does not match`() {
+        StepVerifier.create(IOException("file not found")
+                .toMono<Any>()
+                .onErrorMap(IOException::class, { it.message != "file not found" }, { IllegalStateException("sa") }))
+                .verifyError<IOException>()
     }
 
 }


### PR DESCRIPTION
https://github.com/reactor/reactor-kotlin-extensions/issues/4
This is the implementation for the above suggestion