### PR TITLE
[build] master is 1.1 Europium, introduce new versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ With Gradle from repo.spring.io or Maven Central repositories (stable releases o
 
 ```groovy
     repositories {
-	// maven { url 'https://repo.spring.io/snapshot' }
-	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+	//maven { url 'https://repo.spring.io/milestone' }
 	mavenCentral()
     }
 
     dependencies {
-      //compile "io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.3.BUILD-SNAPSHOT"
-      compile "io.projectreactor.kotlin:reactor-kotlin-extensions:1.0.2.RELEASE"
+      //compile "io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.0-SNAPSHOT"
+      //compile "io.projectreactor.kotlin:reactor-kotlin-extensions:1.1.0"
     }
 ```
 
@@ -29,7 +29,7 @@ With Maven from Maven Central repositories (stable releases):
 <dependency>
     <groupId>io.projectreactor.kotlin</groupId>
     <artifactId>reactor-kotlin-extensions</artifactId>
-    <version>1.0.0.RELEASE</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -42,7 +42,7 @@ Or from repo.spring.io with access to SNAPSHOT:
 	<dependency>
 	    <groupId>io.projectreactor.kotlin</groupId>
 	    <artifactId>reactor-kotlin-extensions</artifactId>
-	    <version>1.0.3.BUILD-SNAPSHOT</version>
+	    <version>1.1.0-SNAPSHOT</version>
 	</dependency>
 	
 </dependencies>

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ configure(rootProject)  { project ->
   group = 'io.projectreactor.kotlin'
 
   repositories {
-	if (version.endsWith('BUILD-SNAPSHOT')) {
+	if (version.endsWith('-SNAPSHOT')) {
 	  maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.3.BUILD-SNAPSHOT
-reactorCoreVersion=3.3.3.BUILD-SNAPSHOT
-reactorAddonsVersion=3.3.3.BUILD-SNAPSHOT
+version=1.1.0-SNAPSHOT
+reactorCoreVersion=3.4.0-SNAPSHOT
+reactorAddonsVersion=3.4.0-SNAPSHOT

--- a/gradle/releaser.gradle
+++ b/gradle/releaser.gradle
@@ -43,7 +43,7 @@ task bumpVersionsInReadme(type: Copy, group: "releaser helpers", description: "r
 	def oldVersion = rootProject.findProperty("oldVersion")
 	def currentVersion = rootProject.findProperty("currentVersion")
 	def nextVersion = rootProject.findProperty("nextVersion")
-	def oldSnapshot = currentVersion?.replace("RELEASE", "BUILD-SNAPSHOT")
+	def oldSnapshot = currentVersion + "-SNAPSHOT"
 
 	onlyIf { oldVersion != null && currentVersion != null && nextVersion != null }
 	dependsOn copyReadme


### PR DESCRIPTION
This commit switches the effort on master from 1.0 to 1.1.0.

It also introduces a new versioning scheme, using -SNAPSHOT
instead of .BUILD-SNAPSHOT as the qualifier for snapshots.
The whole scheme is detailed in the reference documentation of core,
and adaptations are made to the build script to accommodate it.

See reactor/reactor#683