### PR TITLE
Add a `test` extension that takes StepVerifierOptions

### DIFF
--- a/src/main/kotlin/reactor/kotlin/test/StepVerifierExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/test/StepVerifierExtensions.kt
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import reactor.test.StepVerifier.Assertions
 import reactor.test.StepVerifier.LastStep
+import reactor.test.StepVerifierOptions
 import java.time.Duration
 import kotlin.reflect.KClass
 
@@ -100,6 +101,13 @@ fun <T> Flux<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
 fun <T> Flux<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)
 
 /**
+ * Extension for testing [Flux] with [StepVerifier] API.
+ *
+ * @author Cristian Romero
+ */
+fun <T> Flux<T>.test(options: StepVerifierOptions): StepVerifier.FirstStep<T> = StepVerifier.create(this, options)
+
+/**
  * Extension for testing [Mono] with [StepVerifier] API.
  *
  * @author Sebastien Deleuze
@@ -112,3 +120,12 @@ fun <T> Mono<T>.test(): StepVerifier.FirstStep<T> = StepVerifier.create(this)
  * @author Sebastien Deleuze
  */
 fun <T> Mono<T>.test(n: Long): StepVerifier.FirstStep<T> = StepVerifier.create(this, n)
+
+/**
+ * Extension for testing [Mono] with [StepVerifier] API.
+ *
+ * @author Cristian Romero
+ */
+fun <T> Mono<T>.test(options: StepVerifierOptions): StepVerifier.FirstStep<T> = StepVerifier.create(this, options)
+
+


### PR DESCRIPTION
Add a better way to write test assertion using StepVerifierOptions to provide an option to better identify exactly which expectation step caused a test to fail:

StepVerifierOptions.create().scenarioName(String): By using StepVerifierOptions to create your StepVerifier, you can use the scenarioName method to give the whole scenario a name, which is also used in assertion error messages. I think it would be very useful to be able to include it into Kotlin extensions (Flux/Mono).

Example code:

        val  foundUser: Mono<User> = userService.get(1)
        
        val options = StepVerifierOptions.create()
                .scenarioName("scenario testing get user")

        foundUser.test(options)
                .expectNextMatches {
                    it.name=="John"
                }.`as`("user name must be John")
                .verifyComplete() 


I want to discuss about this changes and motivation and more good ideas.
If you don't understand any of above, feel free to comment it.
