### PR TITLE
Renamed switchIfEmpty to switchIfEmptyDeferred

### DIFF
--- a/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
@@ -211,4 +211,4 @@ fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it
  * @author Kevin Davin
  * @since 3.2
  */
-fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })
+fun <T> Flux<T>.switchIfEmptyDeferred(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })

--- a/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
@@ -211,4 +211,16 @@ fun <T : Any> Flux<out Iterable<T>>.split(): Flux<T> = this.flatMapIterable { it
  * @author Kevin Davin
  * @since 3.2
  */
+@Deprecated(
+    "Conflicts with Flux.switchIfEmpty(), use switchIfEmptyDeferred() extension",
+    ReplaceWith("switchIfEmptyDeferred(s)", "reactor.kotlin.core.publisher.switchIfEmptyDeferred"))
+fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmptyDeferred(s)
+
+/**
+ * Extension for [Flux.switchIfEmpty] accepting a function providing a Publisher. This allows having a deferred execution with
+ * the [switchIfEmpty] operator
+ *
+ * @author Kevin Davin
+ * @since 3.2
+ */
 fun <T> Flux<T>.switchIfEmptyDeferred(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })

--- a/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
@@ -221,6 +221,7 @@ fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmp
  * the [switchIfEmpty] operator
  *
  * @author Kevin Davin
- * @since 3.2
+ * @author Pavel Grigorenko
+ * @since 1.1.3
  */
 fun <T> Flux<T>.switchIfEmptyDeferred(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })

--- a/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
@@ -249,5 +249,6 @@ class FluxExtensionsTests {
 
         flux.test()
             .expectError<RuntimeException>()
+            .verify()
     }
 }

--- a/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
@@ -23,6 +23,7 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Operators
+import reactor.kotlin.test.expectError
 import reactor.kotlin.test.test
 import reactor.kotlin.test.verifyError
 import reactor.test.StepVerifier
@@ -226,14 +227,27 @@ class FluxExtensionsTests {
     }
 
     @Test
-    fun `switchIfEmpty with defer execution`() {
+    fun `switchIfEmpty with deferred execution when flux is not empty`() {
         val flux: Flux<Int> = listOf(1, 2, 3)
-                .toFlux()
-                .switchIfEmpty { throw RuntimeException("error which should not happen due to defered execution") }
+            .toFlux()
+            .switchIfEmptyDeferred {
+                throw RuntimeException("error which should not happen due to deferred execution")
+            }
 
-        StepVerifier
-                .create(flux)
-                .expectNext(1, 2, 3)
-                .verifyComplete()
+        flux.test()
+            .expectNext(1, 2, 3)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `switchIfEmpty with deferred execution when flux is empty`() {
+        val flux: Flux<Int> = listOf<Int>()
+            .toFlux()
+            .switchIfEmptyDeferred {
+                throw RuntimeException("Empty!")
+            }
+
+        flux.test()
+            .expectError<RuntimeException>()
     }
 }


### PR DESCRIPTION
Fixes #20 "Problem when using switchIfEmpty on a Flux".
