### PR TITLE
Remove JCenter from build, temporarily fix plugin resolution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,14 @@
 buildscript {
   ext.kotlinVersion = '1.3.72'
   repositories {
-		jcenter()
-		maven { url "https://repo.spring.io/plugins-release" }
+		mavenCentral()
+		maven {
+			//FIXME workaround propdeps not being published to Maven Central + otherwise Gradle somehow tries to load dokka from spring repo
+			url "https://repo.spring.io/plugins-release"
+			content {
+				includeGroup "org.springframework.build.gradle"
+			}
+		}
   }
   dependencies {
 	classpath 'org.springframework.build.gradle:propdeps-plugin:0.0.7'
@@ -45,7 +51,6 @@ configure(rootProject)  { project ->
   group = 'io.projectreactor.kotlin'
 
 	repositories {
-		jcenter()
 		mavenCentral()
 		maven { url "https://oss.sonatype.org/content/repositories/releases/" }
 		maven { url "https://maven-eclipse.github.io/maven" }


### PR DESCRIPTION
Somehow Gradle complains that repo.spring.io plugin repository doesn't
contain the dokka jar, even though mavenCentral() is listed first and
said jar is now on Maven Central. Thus we added a `content` block to
enforce the spring repo is only used to resolve spring gradle plugins.

See reactor/reactor#695.
