### PR TITLE
Renamed branch master to main, update CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: publish
 on:
   push:
     branches: # For branches, better to list them explicitly than regexp include
-      - master
+      - main
       - 1.0.x
 jobs:
   # General job notes: we DON'T want to cancel any previous runs, especially in the case of a "back to snapshots" build right after a release push


### PR DESCRIPTION
This PR is in preparation of renaming branch master to main.
It targets 1.0.x in order to keep the changed files consistent across both
maintained branches.﻿