### PR TITLE
Better extensions for sum/average, deprecate others

### DIFF
--- a/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
@@ -56,7 +56,8 @@ inline fun <reified T:Number> Flux<T>.sumJust(): Mono<T> =
  * Note that summing decimal numbers with this method loses precision, see [sumDouble].
  *
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
+ * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumJust()
  */
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
@@ -108,7 +109,7 @@ fun <T: Number> Flux<T>.sumFloat(): Mono<Float> = MathFlux.sumFloat(this)
  * unexpected sums.
  *
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
 
@@ -176,7 +177,8 @@ inline fun <reified T:Number> Flux<T>.averageJust(): Mono<T> =
  * unexpected averages.
  *
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
+ * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageJust()
  */
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
@@ -233,7 +235,7 @@ fun <T: Number> Flux<T>.averageBigDecimal(): Mono<BigDecimal> = MathFlux.average
  * as a [Mono] of [T].
  *
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
 
@@ -242,7 +244,7 @@ fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
  * as a [Mono] of [T].
  *
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
 
@@ -284,7 +286,8 @@ inline fun <T: Any, reified R: Number> Flux<T>.sumOf(noinline mapper: (T) -> R):
  *
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
+ * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumOf()
  */
 fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
         = MathFlux.sumLong(this, Function(mapper))
@@ -345,7 +348,7 @@ fun <T> Flux<T>.sumFloat(mapper: (T) -> Number): Mono<Float>
  *
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
         = MathFlux.sumDouble(this, Function(mapper))
@@ -421,7 +424,8 @@ inline fun <T: Any, reified R: Number> Flux<T>.averageOf(noinline mapper: (T) ->
  *
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
+ * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageOf()
  */
 fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
         = MathFlux.averageDouble(this, Function(mapper))
@@ -488,7 +492,7 @@ fun <T> Flux<T>.averageBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
  *
  * @param comp The [Comparator] to use
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T> Flux<T>.min(comp: Comparator<T>): Mono<T> = MathFlux.min(this, comp)
 /**
@@ -498,7 +502,7 @@ fun <T> Flux<T>.min(comp: Comparator<T>): Mono<T> = MathFlux.min(this, comp)
  *
  * @param comp The comparison function to use (similar to a [Comparator])
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T> Flux<T>.min(comp: (T, T) -> Int): Mono<T> = MathFlux.min(this, Comparator(comp))
 /**
@@ -507,7 +511,7 @@ fun <T> Flux<T>.min(comp: (T, T) -> Int): Mono<T> = MathFlux.min(this, Comparato
  *
  * @param comp The [Comparator] to use
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T> Flux<T>.max(comp: Comparator<T>): Mono<T> = MathFlux.max(this, comp)
 /**
@@ -517,6 +521,6 @@ fun <T> Flux<T>.max(comp: Comparator<T>): Mono<T> = MathFlux.max(this, comp)
  *
  * @param comp The comparison function to use (similar to a [Comparator])
  * @author Simon Baslé
- * @since 3.1.1
+ * @since 1.0.0
  */
 fun <T> Flux<T>.max(comp: (T, T) -> Int): Mono<T> = MathFlux.max(this, Comparator(comp))

--- a/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
@@ -34,7 +34,7 @@ import java.util.function.Function
  * @since 1.1.5
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <reified T:Number> Flux<T>.sumJust(): Mono<T> =
+inline fun <reified T:Number> Flux<T>.sumAll(): Mono<T> =
     when (T::class) {
         BigDecimal::class -> MathFlux.sumBigDecimal(this) as Mono<T>
         BigInteger::class -> MathFlux.sumBigInteger(this) as Mono<T>
@@ -46,7 +46,7 @@ inline fun <reified T:Number> Flux<T>.sumJust(): Mono<T> =
             .map(Int::toShort) as Mono<T>
         Byte::class -> MathFlux.sumInt(this)
             .map(Int::toByte) as Mono<T>
-        else -> Mono.error( IllegalArgumentException("Flux of ${T::class} is not supported for sumJust()") )
+        else -> Mono.error( IllegalArgumentException("Flux of ${T::class} is not supported for sumAll()") )
     }
 
 /**
@@ -57,7 +57,7 @@ inline fun <reified T:Number> Flux<T>.sumJust(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumJust()
+ * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumAll()
  */
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
@@ -151,7 +151,7 @@ fun <T: Number> Flux<T>.sumBigDecimal(): Mono<BigDecimal> = MathFlux.sumBigDecim
  * @since 1.1.5
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <reified T:Number> Flux<T>.averageJust(): Mono<T> =
+inline fun <reified T:Number> Flux<T>.averageAll(): Mono<T> =
     when (T::class) {
         BigDecimal::class -> MathFlux.averageBigDecimal(this) as Mono<T>
         BigInteger::class -> MathFlux.averageBigInteger(this) as Mono<T>
@@ -165,7 +165,7 @@ inline fun <reified T:Number> Flux<T>.averageJust(): Mono<T> =
             .map(BigInteger::toShort) as Mono<T>
         Byte::class -> MathFlux.averageBigInteger(this)
             .map(BigInteger::toByte) as Mono<T>
-        else -> Mono.error( IllegalArgumentException("Flux of ${T::class} is not supported for averageJust()") )
+        else -> Mono.error( IllegalArgumentException("Flux of ${T::class} is not supported for averageAll()") )
     }
 
 /**
@@ -178,7 +178,7 @@ inline fun <reified T:Number> Flux<T>.averageJust(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageJust()
+ * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageAll()
  */
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
@@ -264,7 +264,7 @@ fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
  * @since 1.1.5
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <T: Any, reified R: Number> Flux<T>.sumOf(noinline mapper: (T) -> R): Mono<R> =
+inline fun <T: Any, reified R: Number> Flux<T>.sumAll(noinline mapper: (T) -> R): Mono<R> =
     when (R::class) {
         BigDecimal::class -> MathFlux.sumBigDecimal(this, Function(mapper)) as Mono<R>
         BigInteger::class -> MathFlux.sumBigInteger(this, Function(mapper)) as Mono<R>
@@ -274,7 +274,7 @@ inline fun <T: Any, reified R: Number> Flux<T>.sumOf(noinline mapper: (T) -> R):
         Int::class -> MathFlux.sumInt(this, Function(mapper)) as Mono<R>
         Short::class -> MathFlux.sumInt(this, Function(mapper)).map(Int::toShort) as Mono<R>
         Byte::class -> MathFlux.sumInt(this, Function(mapper)).map(Int::toByte) as Mono<R>
-        else -> Mono.error( IllegalArgumentException("Mapping of ${R::class} is not supported for sumOf()") )
+        else -> Mono.error( IllegalArgumentException("Mapping of ${R::class} is not supported for sumAll()") )
     }
 
 /**
@@ -287,7 +287,7 @@ inline fun <T: Any, reified R: Number> Flux<T>.sumOf(noinline mapper: (T) -> R):
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumOf()
+ * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumAll()
  */
 fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
         = MathFlux.sumLong(this, Function(mapper))
@@ -397,7 +397,7 @@ fun <T> Flux<T>.sumBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
  * @since 1.1.5
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <T: Any, reified R: Number> Flux<T>.averageOf(noinline mapper: (T) -> R): Mono<R> =
+inline fun <T: Any, reified R: Number> Flux<T>.averageAll(noinline mapper: (T) -> R): Mono<R> =
     when (R::class) {
         BigDecimal::class -> MathFlux.averageBigDecimal(this, Function(mapper)) as Mono<R>
         BigInteger::class -> MathFlux.averageBigInteger(this, Function(mapper)) as Mono<R>
@@ -411,7 +411,7 @@ inline fun <T: Any, reified R: Number> Flux<T>.averageOf(noinline mapper: (T) ->
             .map(BigInteger::toShort) as Mono<R>
         Byte::class -> MathFlux.averageBigInteger(this, Function(mapper))
             .map(BigInteger::toByte) as Mono<R>
-        else -> Mono.error( IllegalArgumentException("Mapping of ${R::class} is not supported for averageOf()") )
+        else -> Mono.error( IllegalArgumentException("Mapping of ${R::class} is not supported for averageAll()") )
     }
 
 /**
@@ -425,7 +425,7 @@ inline fun <T: Any, reified R: Number> Flux<T>.averageOf(noinline mapper: (T) ->
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageOf()
+ * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageAll()
  */
 fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
         = MathFlux.averageDouble(this, Function(mapper))

--- a/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
@@ -58,11 +58,11 @@ inline fun <reified T:Number> Flux<T>.sumAll(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use sumLong() as a direct replacement, or consider more general purpose sumAll().
+ * @deprecated Please use sumAsLong() as a direct replacement, or consider more general purpose sumAll().
  * To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Use sumLong() instead",
-    replaceWith = ReplaceWith("sumLong()","reactor.kotlin.extra.math.sumLong"))
+@Deprecated(message = "Use sumAsLong() instead",
+    replaceWith = ReplaceWith("sumAsLong()","reactor.kotlin.extra.math.sumAsLong"))
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
 /**
@@ -199,11 +199,11 @@ inline fun <reified T:Number> Flux<T>.averageAll(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use averageDouble() as a direct replacement,
+ * @deprecated Please use averageAsDouble() as a direct replacement,
  * or consider more general purpose averageAll(). To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Use averageDouble() instead",
-    replaceWith = ReplaceWith("averageDouble()","reactor.kotlin.extra.math.averageDouble"))
+@Deprecated(message = "Use averageAsDouble() instead",
+    replaceWith = ReplaceWith("averageAsDouble()","reactor.kotlin.extra.math.averageAsDouble"))
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
 /**

--- a/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
@@ -19,8 +19,9 @@ package reactor.kotlin.extra.math
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.math.MathFlux
+import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.function.Function
-
 
 /**
  * Extension to compute the [Long] sum of all values emitted by a [Flux] of [Number]
@@ -34,6 +35,45 @@ import java.util.function.Function
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
 /**
+ * Extension to compute the [Int] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Int].
+ *
+ * Note that numbers will be mapped to [Int] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumInt(): Mono<Int> = MathFlux.sumInt(this)
+
+/**
+ * Extension to compute the [Long] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Long].
+ *
+ * Note that numbers will be mapped to [Long] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumLong(): Mono<Long> = MathFlux.sumLong(this)
+
+/**
+ * Extension to compute the [Float] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Float].
+ *
+ * Note that numbers will be mapped to [Float] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumFloat(): Mono<Float> = MathFlux.sumFloat(this)
+
+/**
  * Extension to compute the [Double] sum of all values emitted by a [Flux] of [Number]
  * and return it as a [Mono] of [Double].
  *
@@ -45,6 +85,33 @@ fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
  * @since 3.1.1
  */
 fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
+
+/**
+ * Extension to compute the [BigInteger] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [BigInteger].
+ *
+ * Note that numbers will be mapped to [BigInteger] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumBigInt(): Mono<BigInteger> = MathFlux.sumBigInteger(this)
+
+/**
+ * Extension to compute the [BigDecimal] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [BigDecimal].
+ *
+ * Note that numbers will be mapped to [BigDecimal] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumBigDecimal(): Mono<BigDecimal> = MathFlux.sumBigDecimal(this)
+
 /**
  * Extension to compute the [Double] average of all values emitted by a [Flux] of [Number]
  * and return it as a [Mono] of [Double].
@@ -58,6 +125,53 @@ fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
  */
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
+/**
+ * Extension to compute the [Float] average of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Float].
+ *
+ * Note that numbers will be mapped to [Float] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.averageFloat(): Mono<Float> = MathFlux.averageFloat(this)
+
+/**
+ * Extension to compute the [Double] average of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Double].
+ *
+ * Note that numbers will be mapped to [Double] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.averageDouble(): Mono<Double> = MathFlux.averageDouble(this)
+
+/**
+ * Extension to compute the [BigInteger] average of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [BigInteger].
+ *
+ * Note that the result will be mapped to [BigInteger] and is likely to lose precision
+ * during the calculation of the average
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.averageBigInt(): Mono<BigInteger> = MathFlux.averageBigInteger(this)
+
+/**
+ * Extension to compute the [BigDecimal] average of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [BigDecimal].
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.averageBigDecimal(): Mono<BigDecimal> = MathFlux.averageBigDecimal(this)
+
 //min and max that work on any comparable
 /**
  * Extension to find the lowest value in a [Flux] of [Comparable] values and return it
@@ -67,6 +181,7 @@ fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
  * @since 3.1.1
  */
 fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
+
 /**
  * Extension to find the highest value in a [Flux] of [Comparable] values and return it
  * as a [Mono] of [T].
@@ -77,6 +192,7 @@ fun <T: Comparable<T>> Flux<T>.min(): Mono<T> = MathFlux.min(this)
 fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
 
 //sum/sumDouble/average lambda versions where a converter is provided
+
 /**
  * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
  * Numbers as a [Mono] of [Long].
@@ -90,6 +206,52 @@ fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
  */
 fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
         = MathFlux.sumLong(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [Int].
+ *
+ * Note that numbers will be mapped to [Int] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.sumInt(mapper: (T) -> Number): Mono<Int>
+        = MathFlux.sumInt(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [Long].
+ *
+ * Note that numbers will be mapped to [Long] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.sumLong(mapper: (T) -> Number): Mono<Long>
+        = MathFlux.sumLong(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [Float].
+ *
+ * Note that numbers will be mapped to [Float] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.sumFloat(mapper: (T) -> Number): Mono<Float>
+        = MathFlux.sumFloat(this, Function(mapper))
+
 /**
  * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
  * Numbers as a [Mono] of [Double], thus avoiding rounding
@@ -105,6 +267,37 @@ fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
  */
 fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
         = MathFlux.sumDouble(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [BigInteger]
+ *
+ * Note that numbers will be mapped to [BigInteger] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.sumBigInt(mapper: (T) -> Number): Mono<BigInteger>
+        = MathFlux.sumBigInteger(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
+ * Numbers as a [Mono] of [BigInteger]
+ *
+ * Note that numbers will be mapped to [BigInteger] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.sumBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
+        = MathFlux.sumBigDecimal(this, Function(mapper))
+
 /**
  * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
  * these Numbers as a [Mono] of [Double].
@@ -120,6 +313,60 @@ fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
 fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
         = MathFlux.averageDouble(this, Function(mapper))
 
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
+ * these Numbers as a [Mono] of [Float].
+ *
+ * Note that numbers will be mapped to [Float] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.averageFloat(mapper: (T) -> Number): Mono<Float>
+        = MathFlux.averageFloat(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
+ * these Numbers as a [Mono] of [Double].
+ *
+ * Note that numbers will be mapped to [Double] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.averageDouble(mapper: (T) -> Number): Mono<Double>
+        = MathFlux.averageDouble(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
+ * these Numbers as a [Mono] of [BigInteger].
+ *
+ * Note that the result will be mapped to [BigInteger] and is likely to lose precision
+ * during the calculation of the average
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.averageBigInt(mapper: (T) -> Number): Mono<BigInteger>
+        = MathFlux.averageBigInteger(this, Function(mapper))
+
+/**
+ * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
+ * these Numbers as a [Mono] of [BigDecimal].
+ *
+ * @param mapper a lambda converting values to [Number]
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T> Flux<T>.averageBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
+        = MathFlux.averageBigDecimal(this, Function(mapper))
 
 //min/max lambda versions where a comparator or equivalent function is provided
 /**

--- a/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/math/MathFluxExtensions.kt
@@ -27,8 +27,9 @@ import java.util.function.Function
  * General purpose extension function to compute the sum of all values emitted by a [Flux] of [Number]
  * and return it as a [Mono]. The resultant [Mono] will have the same [Number] type as the input [Flux]
  *
- * If the result type (or precision) needs to be changed then a specific sumType() method
- * should be used in preference to this method.
+ * If the result type (or precision) needs to be changed then a specific sumAsType() method
+ * should be used in preference to this method. e.g. sumAsDouble() can be used to compute
+ * the sum as a [Mono] of [Double]
  *
  * @author Mark Pruden
  * @since 1.1.5
@@ -57,8 +58,11 @@ inline fun <reified T:Number> Flux<T>.sumAll(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumAll()
+ * @deprecated Please use sumLong() as a direct replacement, or consider more general purpose sumAll().
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use sumLong() instead",
+    replaceWith = ReplaceWith("sumLong()","reactor.kotlin.extra.math.sumLong"))
 fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
 
 /**
@@ -72,7 +76,7 @@ fun <T: Number> Flux<T>.sum(): Mono<Long> = MathFlux.sumLong(this)
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.sumInt(): Mono<Int> = MathFlux.sumInt(this)
+fun <T: Number> Flux<T>.sumAsInt(): Mono<Int> = MathFlux.sumInt(this)
 
 /**
  * Extension to compute the [Long] sum of all values emitted by a [Flux] of [Number]
@@ -85,7 +89,7 @@ fun <T: Number> Flux<T>.sumInt(): Mono<Int> = MathFlux.sumInt(this)
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.sumLong(): Mono<Long> = MathFlux.sumLong(this)
+fun <T: Number> Flux<T>.sumAsLong(): Mono<Long> = MathFlux.sumLong(this)
 
 /**
  * Extension to compute the [Float] sum of all values emitted by a [Flux] of [Number]
@@ -98,7 +102,20 @@ fun <T: Number> Flux<T>.sumLong(): Mono<Long> = MathFlux.sumLong(this)
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.sumFloat(): Mono<Float> = MathFlux.sumFloat(this)
+fun <T: Number> Flux<T>.sumAsFloat(): Mono<Float> = MathFlux.sumFloat(this)
+
+/**
+ * Extension to compute the [Double] sum of all values emitted by a [Flux] of [Number]
+ * and return it as a [Mono] of [Double].
+ *
+ * Note that numbers will be mapped to [Double] using Java standard conversions
+ * This may lead to arbitrary precision gain or loss if the source flux contains different types
+ * Please choose an appropriate method based on the expected types in the source flux.
+ *
+ * @author Mark Pruden
+ * @since 1.1.5
+ */
+fun <T: Number> Flux<T>.sumAsDouble(): Mono<Float> = MathFlux.sumFloat(this)
 
 /**
  * Extension to compute the [Double] sum of all values emitted by a [Flux] of [Number]
@@ -110,7 +127,11 @@ fun <T: Number> Flux<T>.sumFloat(): Mono<Float> = MathFlux.sumFloat(this)
  *
  * @author Simon Baslé
  * @since 1.0.0
+ * @deprecated Please use sumAsDouble() as a direct replacement, or consider more general purpose sumAll().
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use sumAsDouble() instead",
+    replaceWith = ReplaceWith("sumAsDouble()","reactor.kotlin.extra.math.sumAsDouble"))
 fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
 
 /**
@@ -124,7 +145,7 @@ fun <T: Number> Flux<T>.sumDouble(): Mono<Double> = MathFlux.sumDouble(this)
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.sumBigInt(): Mono<BigInteger> = MathFlux.sumBigInteger(this)
+fun <T: Number> Flux<T>.sumAsBigInt(): Mono<BigInteger> = MathFlux.sumBigInteger(this)
 
 /**
  * Extension to compute the [BigDecimal] sum of all values emitted by a [Flux] of [Number]
@@ -137,15 +158,15 @@ fun <T: Number> Flux<T>.sumBigInt(): Mono<BigInteger> = MathFlux.sumBigInteger(t
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.sumBigDecimal(): Mono<BigDecimal> = MathFlux.sumBigDecimal(this)
+fun <T: Number> Flux<T>.sumAsBigDecimal(): Mono<BigDecimal> = MathFlux.sumBigDecimal(this)
 
 /**
  * General purpose extension function to compute the average of all values emitted by a [Flux] of [Number]
  * and return it as a [Mono]. The resultant [Mono] will have the same [Number] type as the input [Flux]
  *
- * If the result type (or precision) needs to be changed then a specific averageType() method
- * should be used in preference to this method. e.g. averageDouble() can be used to compute average
- * of any [Flux] of [Number] into a [Double]
+ * If the result type (or precision) needs to be changed then a specific averageAsType() method
+ * should be used in preference to this method. e.g. averageAsDouble() can be used to compute
+ * the average as a [Mono] of [Double]
  *
  * @author Mark Pruden
  * @since 1.1.5
@@ -178,8 +199,11 @@ inline fun <reified T:Number> Flux<T>.averageAll(): Mono<T> =
  *
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageAll()
+ * @deprecated Please use averageDouble() as a direct replacement,
+ * or consider more general purpose averageAll(). To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use averageDouble() instead",
+    replaceWith = ReplaceWith("averageDouble()","reactor.kotlin.extra.math.averageDouble"))
 fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
 
 /**
@@ -193,7 +217,7 @@ fun <T: Number> Flux<T>.average(): Mono<Double> = MathFlux.averageDouble(this)
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.averageFloat(): Mono<Float> = MathFlux.averageFloat(this)
+fun <T: Number> Flux<T>.averageAsFloat(): Mono<Float> = MathFlux.averageFloat(this)
 
 /**
  * Extension to compute the [Double] average of all values emitted by a [Flux] of [Number]
@@ -206,7 +230,7 @@ fun <T: Number> Flux<T>.averageFloat(): Mono<Float> = MathFlux.averageFloat(this
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.averageDouble(): Mono<Double> = MathFlux.averageDouble(this)
+fun <T: Number> Flux<T>.averageAsDouble(): Mono<Double> = MathFlux.averageDouble(this)
 
 /**
  * Extension to compute the [BigInteger] average of all values emitted by a [Flux] of [Number]
@@ -218,7 +242,7 @@ fun <T: Number> Flux<T>.averageDouble(): Mono<Double> = MathFlux.averageDouble(t
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.averageBigInt(): Mono<BigInteger> = MathFlux.averageBigInteger(this)
+fun <T: Number> Flux<T>.averageAsBigInt(): Mono<BigInteger> = MathFlux.averageBigInteger(this)
 
 /**
  * Extension to compute the [BigDecimal] average of all values emitted by a [Flux] of [Number]
@@ -227,7 +251,7 @@ fun <T: Number> Flux<T>.averageBigInt(): Mono<BigInteger> = MathFlux.averageBigI
  * @author Mark Pruden
  * @since 1.1.5
  */
-fun <T: Number> Flux<T>.averageBigDecimal(): Mono<BigDecimal> = MathFlux.averageBigDecimal(this)
+fun <T: Number> Flux<T>.averageAsBigDecimal(): Mono<BigDecimal> = MathFlux.averageBigDecimal(this)
 
 //min and max that work on any comparable
 /**
@@ -255,9 +279,9 @@ fun <T: Comparable<T>> Flux<T>.max(): Mono<T> = MathFlux.max(this)
  * return the sum of these Numbers as a [Mono] of [Number].
  * The resultant [Mono] will have the same [Number] type as the output of the mapping function
  *
- * If the result type (or precision) needs to be changed then a specific sumType() method
- * should be used in preference to this method. e.g. sumDouble(mapper) can be used to compute
- * the average as a [Mono] of [Double]
+ * If the result type (or precision) needs to be changed then a specific sumAsType() method
+ * should be used in preference to this method. e.g. sumAsDouble() can be used to compute
+ * the sum as a [Mono] of [Double]
  *
  * @param mapper a lambda converting values to [Number]
  * @author Mark Pruden
@@ -287,55 +311,13 @@ inline fun <T: Any, reified R: Number> Flux<T>.sumAll(noinline mapper: (T) -> R)
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use sumLong() as a direct replacement of consider more general purpose sumAll()
+ * @deprecated Please use sumAll(mapper) as a direct replacement,
+ * providing a mapping function that returns a Long. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use sumAll(mapper) instead",
+    replaceWith = ReplaceWith("sumAll(mapper)","reactor.kotlin.extra.math.sumAll"))
 fun <T> Flux<T>.sum(mapper: (T) -> Number): Mono<Long>
         = MathFlux.sumLong(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
- * Numbers as a [Mono] of [Int].
- *
- * Note that numbers will be mapped to [Int] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.sumInt(mapper: (T) -> Number): Mono<Int>
-        = MathFlux.sumInt(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
- * Numbers as a [Mono] of [Long].
- *
- * Note that numbers will be mapped to [Long] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.sumLong(mapper: (T) -> Number): Mono<Long>
-        = MathFlux.sumLong(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
- * Numbers as a [Mono] of [Float].
- *
- * Note that numbers will be mapped to [Float] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.sumFloat(mapper: (T) -> Number): Mono<Float>
-        = MathFlux.sumFloat(this, Function(mapper))
 
 /**
  * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
@@ -349,47 +331,21 @@ fun <T> Flux<T>.sumFloat(mapper: (T) -> Number): Mono<Float>
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
  * @since 1.0.0
+ * @deprecated Please use sumAll(mapper) as a direct replacement,
+ * providing a mapper function that returns a Double. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use sumAll(mapper) instead",
+    replaceWith = ReplaceWith("sumAll(mapper)","reactor.kotlin.extra.math.sumAll"))
 fun <T> Flux<T>.sumDouble(mapper: (T) -> Number): Mono<Double>
         = MathFlux.sumDouble(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
- * Numbers as a [Mono] of [BigInteger]
- *
- * Note that numbers will be mapped to [BigInteger] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.sumBigInt(mapper: (T) -> Number): Mono<BigInteger>
-        = MathFlux.sumBigInteger(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the sum of these
- * Numbers as a [Mono] of [BigInteger]
- *
- * Note that numbers will be mapped to [BigInteger] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.sumBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
-        = MathFlux.sumBigDecimal(this, Function(mapper))
 
 /**
  * General purpose extension function to map arbitrary values in a [Flux] to [Number]s and
  * return the average of these Numbers as a [Mono] of [Number].
  * The resultant [Mono] will have the same [Number] type as the output of the mapping function
  *
- * If the result type (or precision) needs to be changed then a specific averageType() method
- * should be used in preference to this method. e.g. averageDouble(mapper) can be used to compute
+ * If the result type (or precision) needs to be changed then a specific averageAsType() method
+ * should be used in preference to this method. e.g. averageAsDouble() can be used to compute
  * the average as a [Mono] of [Double]
  *
  * @param mapper a lambda converting values to [Number]
@@ -425,67 +381,16 @@ inline fun <T: Any, reified R: Number> Flux<T>.averageAll(noinline mapper: (T) -
  * @param mapper a lambda converting values to [Number]
  * @author Simon Baslé
  * @since 1.0.0
- * @deprecated Please use averageDouble() as a direct replacement of consider more general purpose averageAll()
+ * @deprecated Please use averageAll(mapper) as a direct replacement,
+ * providing a mapper function that returns a Double. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Use averageAll(mapper) instead",
+    replaceWith = ReplaceWith("averageAll(mapper)","reactor.kotlin.extra.math.averageAll"))
 fun <T> Flux<T>.average(mapper: (T) -> Number): Mono<Double>
         = MathFlux.averageDouble(this, Function(mapper))
 
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
- * these Numbers as a [Mono] of [Float].
- *
- * Note that numbers will be mapped to [Float] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.averageFloat(mapper: (T) -> Number): Mono<Float>
-        = MathFlux.averageFloat(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
- * these Numbers as a [Mono] of [Double].
- *
- * Note that numbers will be mapped to [Double] using Java standard conversions
- * This may lead to arbitrary precision gain or loss if the source flux contains different types
- * Please choose an appropriate method based on the expected types in the source flux.
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.averageDouble(mapper: (T) -> Number): Mono<Double>
-        = MathFlux.averageDouble(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
- * these Numbers as a [Mono] of [BigInteger].
- *
- * Note that the result will be mapped to [BigInteger] and is likely to lose precision
- * during the calculation of the average
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.averageBigInt(mapper: (T) -> Number): Mono<BigInteger>
-        = MathFlux.averageBigInteger(this, Function(mapper))
-
-/**
- * Extension to map arbitrary values in a [Flux] to [Number]s and return the average of
- * these Numbers as a [Mono] of [BigDecimal].
- *
- * @param mapper a lambda converting values to [Number]
- * @author Mark Pruden
- * @since 1.1.5
- */
-fun <T> Flux<T>.averageBigDecimal(mapper: (T) -> Number): Mono<BigDecimal>
-        = MathFlux.averageBigDecimal(this, Function(mapper))
-
 //min/max lambda versions where a comparator or equivalent function is provided
+
 /**
  * Extension to find the lowest value in a [Flux] and return it as a [Mono]. The lowest
  * value is defined by comparisons made using a provided [Comparator].

--- a/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
@@ -20,6 +20,8 @@ import org.junit.Test
 import reactor.core.publisher.Flux
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.test.test
+import java.math.BigDecimal
+import java.math.BigInteger
 
 /**
  * @author Simon Baslé
@@ -98,6 +100,189 @@ class MathFluxExtensionsTests {
                 .verifyComplete()
     }
 
+    //== sumInt ==
+
+    @Test
+    fun sumIntShorts() {
+        shortArrayOf(32_000, 32_000) //sum overflows a Short
+            .toFlux()
+            .sumInt()
+            .test()
+            .expectNext(64_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumIntInts() {
+        intArrayOf(300_000_000, 200_000_000)
+            .toFlux()
+            .sumInt()
+            .test()
+            .expectNext(500_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumIntLongs() {
+        longArrayOf(300_000_000, 200_000_000)
+            .toFlux()
+            .sumInt()
+            .test()
+            .expectNext(500_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumIntFloats() {
+        floatArrayOf(3.5f, 1.9f)
+            .toFlux()
+            .sumInt()
+            .test()
+            .expectNext(4)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumIntDoubles() {
+        doubleArrayOf(3.5, 1.5)
+            .toFlux()
+            .sumInt()
+            .test()
+            .expectNext(4)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumIntMapped() {
+        userList.toFlux()
+            .sumInt { it.age }
+            .test()
+            .expectNext(99)
+            .verifyComplete()
+    }
+
+    //== sumLong ==
+
+    @Test
+    fun sumLongShorts() {
+        shortArrayOf(32_000, 32_000) //sum overflows a Short
+            .toFlux()
+            .sumLong()
+            .test()
+            .expectNext(64_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumLongInts() {
+        intArrayOf(2_000_000_000, 2_000_000_000) //sum overflows an Int
+            .toFlux()
+            .sumLong()
+            .test()
+            .expectNext(4_000_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumLongLongs() {
+        longArrayOf(300_000_000_000, 200_000_000_000)
+            .toFlux()
+            .sumLong()
+            .test()
+            .expectNext(500_000_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumLongFloats() {
+        floatArrayOf(3.5f, 1.9f)
+            .toFlux()
+            .sumLong()
+            .test()
+            .expectNext(4)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumLongDoubles() {
+        doubleArrayOf(3.5, 1.5)
+            .toFlux()
+            .sumLong()
+            .test()
+            .expectNext(4)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumLongMapped() {
+        userList.toFlux()
+            .sumLong { it.age }
+            .test()
+            .expectNext(99)
+            .verifyComplete()
+    }
+
+    //== sumFloat ==
+
+    @Test
+    fun sumFloatShorts() {
+        shortArrayOf(32_000, 32_000) //sum overflows a Short
+            .toFlux()
+            .sumFloat()
+            .test()
+            .expectNext(64000F)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatInts() {
+        intArrayOf(2_000_000_000, 2_000_000_000) //sum overflows an Int
+            .toFlux()
+            .sumFloat()
+            .test()
+            .expectNext(4E9F)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatLongs() {
+        longArrayOf(30_000_000_000, 20_000_000_000) // There is some precision loss in these conversions.
+            .toFlux()
+            .sumFloat()
+            .test()
+            .expectNext(5.0000003E10F)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatFloats() {
+        floatArrayOf(3.5f, 1.9f)
+            .toFlux()
+            .sumFloat()
+            .test()
+            .expectNext(5.4F)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatDoubles() {
+        doubleArrayOf(3.5, 1.9)
+            .toFlux()
+            .sumFloat()
+            .test()
+            .expectNext(5.4F)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumFloatMapped() {
+        userList.toFlux()
+            .sumFloat { it.age }
+            .test()
+            .expectNext(99.0F)
+            .verifyComplete()
+    }
+
     //== sumDouble ==
     @Test
     fun sumDoubleShorts() {
@@ -158,7 +343,130 @@ class MathFluxExtensionsTests {
                 .verifyComplete()
     }
 
+    //== sumBigInt ==
+
+    @Test
+    fun sumBigIntegerShorts() {
+        shortArrayOf(32_000, 32_000)
+            .toFlux()
+            .sumBigInt()
+            .test()
+            .expectNext(BigInteger("64000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigIntegerInts() {
+        intArrayOf(2_000_000_000, 2_000_000_000)
+            .toFlux()
+            .sumBigInt()
+            .test()
+            .expectNext(BigInteger("4000000000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigIntegerLongs() {
+        longArrayOf(30_000_000_000, 20_000_000_000)
+            .toFlux()
+            .sumBigInt()
+            .test()
+            .expectNext(BigInteger("50000000000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigIntegerFloats() {
+        floatArrayOf(3.9f, 1.9f)
+            .toFlux()
+            .sumBigInt()
+            .test()
+            .expectNext(BigInteger("4"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigIntegerDoubles() {
+        doubleArrayOf(3.9, 1.9)
+            .toFlux()
+            .sumBigInt()
+            .test()
+            .expectNext(BigInteger("4"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigIntegerMapped() {
+        userList.toFlux()
+            .sumBigInt { it.age }
+            .test()
+            .expectNext(BigInteger("99"))
+            .verifyComplete()
+    }
+
+    //== sumBigDecimal ==
+
+    @Test
+    fun sumBigDecimalShorts() {
+        shortArrayOf(32_000, 32_000)
+            .toFlux()
+            .sumBigDecimal()
+            .test()
+            .expectNext(BigDecimal("64000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigDecimalInts() {
+        intArrayOf(2_000_000_000, 2_000_000_000)
+            .toFlux()
+            .sumBigDecimal()
+            .test()
+            .expectNext(BigDecimal("4000000000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigDecimalLongs() {
+        longArrayOf(30_000_000_000, 20_000_000_000)
+            .toFlux()
+            .sumBigDecimal()
+            .test()
+            .expectNext(BigDecimal("50000000000"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigDecimalFloats() {
+        floatArrayOf(3.5f, 1.99f)
+            .toFlux()
+            .sumBigDecimal()
+            .test()
+            .expectNext(BigDecimal("5.49"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigDecimalDoubles() {
+        doubleArrayOf(3.5, 1.99)
+            .toFlux()
+            .sumBigDecimal()
+            .test()
+            .expectNext(BigDecimal("5.49"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumBigDecimalMapped() {
+        userList.toFlux()
+            .sumBigDecimal { it.age }
+            .test()
+            .expectNext(BigDecimal("99"))
+            .verifyComplete()
+    }
+
     //== average ==
+
     @Test
     fun averageShorts() {
         shortArrayOf(10, 11)
@@ -216,6 +524,250 @@ class MathFluxExtensionsTests {
                 .test()
                 .expectNext(33.0)
                 .verifyComplete()
+    }
+
+    //== averageFloat ==
+
+    @Test
+    fun averageFloatShorts() {
+        shortArrayOf(10, 11)
+            .toFlux()
+            .averageFloat()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageFloatInts() {
+        intArrayOf(10, 11)
+            .toFlux()
+            .averageFloat()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageFloatLongs() {
+        longArrayOf(10, 11)
+            .toFlux()
+            .averageFloat()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageFloatFloats() {
+        floatArrayOf(10f, 11f)
+            .toFlux()
+            .averageFloat()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageFloatDoubles() {
+        doubleArrayOf(10.0, 11.0)
+            .toFlux()
+            .averageFloat()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageFloatMapped() {
+        userList.toFlux()
+            .averageFloat { it.age }
+            .test()
+            .expectNext(33.0f)
+            .verifyComplete()
+    }
+
+    //== averageDouble ==
+
+    @Test
+    fun averageDoubleShorts() {
+        shortArrayOf(10, 11)
+            .toFlux()
+            .averageDouble()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubleInts() {
+        intArrayOf(10, 11)
+            .toFlux()
+            .averageDouble()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubleLongs() {
+        longArrayOf(10, 11)
+            .toFlux()
+            .averageDouble()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubleFloats() {
+        floatArrayOf(10f, 11f)
+            .toFlux()
+            .averageDouble()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubleDoubles() {
+        doubleArrayOf(10.0, 11.0)
+            .toFlux()
+            .averageDouble()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageDoubleMapped() {
+        userList.toFlux()
+            .averageDouble { it.age }
+            .test()
+            .expectNext(33.0)
+            .verifyComplete()
+    }
+
+    //== averageBigInt ==
+
+    @Test
+    fun averageBigIntShorts() {
+        shortArrayOf(10, 11, 12)
+            .toFlux()
+            .averageBigInt()
+            .test()
+            .expectNext(BigInteger("11"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigIntInts() {
+        intArrayOf(10, 11, 12)
+            .toFlux()
+            .averageBigInt()
+            .test()
+            .expectNext(BigInteger("11"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigIntLongs() {
+        longArrayOf(10, 11, 12)
+            .toFlux()
+            .averageBigInt()
+            .test()
+            .expectNext(BigInteger("11"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigIntFloats() {
+        floatArrayOf(10f, 11f, 12f)
+            .toFlux()
+            .averageBigInt()
+            .test()
+            .expectNext(BigInteger("11"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigIntDoubles() {
+        doubleArrayOf(10.0, 11.0, 12.0)
+            .toFlux()
+            .averageBigInt()
+            .test()
+            .expectNext(BigInteger("11"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigIntMapped() {
+        userList.toFlux()
+            .averageBigInt { it.age }
+            .test()
+            .expectNext(BigInteger("33"))
+            .verifyComplete()
+    }
+
+    //== averageBigDecimal ==
+
+    @Test
+    fun averageBigDecimalShorts() {
+        shortArrayOf(10, 11, 11, 11)
+            .toFlux()
+            .averageBigDecimal()
+            .test()
+            .expectNext(BigDecimal("10.75"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigDecimalInts() {
+        intArrayOf(10, 11, 11, 11)
+            .toFlux()
+            .averageBigDecimal()
+            .test()
+            .expectNext(BigDecimal("10.75"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigDecimalLongs() {
+        longArrayOf(10, 11, 11, 11)
+            .toFlux()
+            .averageBigDecimal()
+            .test()
+            .expectNext(BigDecimal("10.75"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigDecimalFloats() {
+        floatArrayOf(10f, 11f, 12f, 13.5f)
+            .toFlux()
+            .averageBigDecimal()
+            .test()
+            .expectNext(BigDecimal("11.625"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigDecimalDoubles() {
+        doubleArrayOf(10.0, 11.0, 12.0, 13.5)
+            .toFlux()
+            .averageBigDecimal()
+            .test()
+            .expectNext(BigDecimal("11.625"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageBigDecimalMapped() {
+        userList.toFlux()
+            .averageBigDecimal { it.age }
+            .test()
+            .expectNext(BigDecimal("33"))
+            .verifyComplete()
     }
 
     //== min ==

--- a/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
@@ -46,7 +46,7 @@ class MathFluxExtensionsTests {
     fun sumJustShorts() {
         shortArrayOf(15_000, 16_000)
             .toFlux()
-            .sumJust()
+            .sumAll()
             .test()
             .expectNext(31_000)
             .verifyComplete()
@@ -56,7 +56,7 @@ class MathFluxExtensionsTests {
     fun sumJustInts() {
         intArrayOf(200_000_000, 200_000_000)
             .toFlux()
-            .sumJust()
+            .sumAll()
             .test()
             .expectNext(400_000_000)
             .verifyComplete()
@@ -66,7 +66,7 @@ class MathFluxExtensionsTests {
     fun sumJustLongs() {
         longArrayOf(3_000_000_000, 2_000_000_000)
             .toFlux()
-            .sumJust()
+            .sumAll()
             .test()
             .expectNext(5_000_000_000)
             .verifyComplete()
@@ -76,7 +76,7 @@ class MathFluxExtensionsTests {
     fun sumJustFloats() {
         floatArrayOf(3.6f, 1.5f)
             .toFlux()
-            .sumJust()
+            .sumAll()
             .test()
             .expectNext(5.1f)
             .verifyComplete()
@@ -86,7 +86,7 @@ class MathFluxExtensionsTests {
     fun sumJustDoubles() {
         doubleArrayOf(3.5, 1.6)
             .toFlux()
-            .sumJust()
+            .sumAll()
             .test()
             .expectNext(5.1)
             .verifyComplete()
@@ -95,7 +95,7 @@ class MathFluxExtensionsTests {
     @Test
     fun sumOfMapped() {
         userList.toFlux()
-            .sumOf { it.age }
+            .sumAll { it.age }
             .test()
             .expectNext(99)
             .verifyComplete()
@@ -167,7 +167,7 @@ class MathFluxExtensionsTests {
     fun sumIntShorts() {
         shortArrayOf(32_000, 32_000) //sum overflows a Short
             .toFlux()
-            .sumInt()
+            .sumAsInt()
             .test()
             .expectNext(64_000)
             .verifyComplete()
@@ -177,7 +177,7 @@ class MathFluxExtensionsTests {
     fun sumIntInts() {
         intArrayOf(300_000_000, 200_000_000)
             .toFlux()
-            .sumInt()
+            .sumAsInt()
             .test()
             .expectNext(500_000_000)
             .verifyComplete()
@@ -187,7 +187,7 @@ class MathFluxExtensionsTests {
     fun sumIntLongs() {
         longArrayOf(300_000_000, 200_000_000)
             .toFlux()
-            .sumInt()
+            .sumAsInt()
             .test()
             .expectNext(500_000_000)
             .verifyComplete()
@@ -197,7 +197,7 @@ class MathFluxExtensionsTests {
     fun sumIntFloats() {
         floatArrayOf(3.5f, 1.9f)
             .toFlux()
-            .sumInt()
+            .sumAsInt()
             .test()
             .expectNext(4)
             .verifyComplete()
@@ -207,18 +207,9 @@ class MathFluxExtensionsTests {
     fun sumIntDoubles() {
         doubleArrayOf(3.5, 1.5)
             .toFlux()
-            .sumInt()
+            .sumAsInt()
             .test()
             .expectNext(4)
-            .verifyComplete()
-    }
-
-    @Test
-    fun sumIntMapped() {
-        userList.toFlux()
-            .sumInt { it.age }
-            .test()
-            .expectNext(99)
             .verifyComplete()
     }
 
@@ -228,7 +219,7 @@ class MathFluxExtensionsTests {
     fun sumLongShorts() {
         shortArrayOf(32_000, 32_000) //sum overflows a Short
             .toFlux()
-            .sumLong()
+            .sumAsLong()
             .test()
             .expectNext(64_000)
             .verifyComplete()
@@ -238,7 +229,7 @@ class MathFluxExtensionsTests {
     fun sumLongInts() {
         intArrayOf(2_000_000_000, 2_000_000_000) //sum overflows an Int
             .toFlux()
-            .sumLong()
+            .sumAsLong()
             .test()
             .expectNext(4_000_000_000)
             .verifyComplete()
@@ -248,7 +239,7 @@ class MathFluxExtensionsTests {
     fun sumLongLongs() {
         longArrayOf(300_000_000_000, 200_000_000_000)
             .toFlux()
-            .sumLong()
+            .sumAsLong()
             .test()
             .expectNext(500_000_000_000)
             .verifyComplete()
@@ -258,7 +249,7 @@ class MathFluxExtensionsTests {
     fun sumLongFloats() {
         floatArrayOf(3.5f, 1.9f)
             .toFlux()
-            .sumLong()
+            .sumAsLong()
             .test()
             .expectNext(4)
             .verifyComplete()
@@ -268,18 +259,9 @@ class MathFluxExtensionsTests {
     fun sumLongDoubles() {
         doubleArrayOf(3.5, 1.5)
             .toFlux()
-            .sumLong()
+            .sumAsLong()
             .test()
             .expectNext(4)
-            .verifyComplete()
-    }
-
-    @Test
-    fun sumLongMapped() {
-        userList.toFlux()
-            .sumLong { it.age }
-            .test()
-            .expectNext(99)
             .verifyComplete()
     }
 
@@ -289,7 +271,7 @@ class MathFluxExtensionsTests {
     fun sumFloatShorts() {
         shortArrayOf(32_000, 32_000) //sum overflows a Short
             .toFlux()
-            .sumFloat()
+            .sumAsFloat()
             .test()
             .expectNext(64000F)
             .verifyComplete()
@@ -299,7 +281,7 @@ class MathFluxExtensionsTests {
     fun sumFloatInts() {
         intArrayOf(2_000_000_000, 2_000_000_000) //sum overflows an Int
             .toFlux()
-            .sumFloat()
+            .sumAsFloat()
             .test()
             .expectNext(4E9F)
             .verifyComplete()
@@ -309,7 +291,7 @@ class MathFluxExtensionsTests {
     fun sumFloatLongs() {
         longArrayOf(30_000_000_000, 20_000_000_000) // There is some precision loss in these conversions.
             .toFlux()
-            .sumFloat()
+            .sumAsFloat()
             .test()
             .expectNext(5.0000003E10F)
             .verifyComplete()
@@ -319,7 +301,7 @@ class MathFluxExtensionsTests {
     fun sumFloatFloats() {
         floatArrayOf(3.5f, 1.9f)
             .toFlux()
-            .sumFloat()
+            .sumAsFloat()
             .test()
             .expectNext(5.4F)
             .verifyComplete()
@@ -329,18 +311,9 @@ class MathFluxExtensionsTests {
     fun sumFloatDoubles() {
         doubleArrayOf(3.5, 1.9)
             .toFlux()
-            .sumFloat()
+            .sumAsFloat()
             .test()
             .expectNext(5.4F)
-            .verifyComplete()
-    }
-
-    @Test
-    fun sumFloatMapped() {
-        userList.toFlux()
-            .sumFloat { it.age }
-            .test()
-            .expectNext(99.0F)
             .verifyComplete()
     }
 
@@ -410,7 +383,7 @@ class MathFluxExtensionsTests {
     fun sumBigIntegerShorts() {
         shortArrayOf(32_000, 32_000)
             .toFlux()
-            .sumBigInt()
+            .sumAsBigInt()
             .test()
             .expectNext(BigInteger("64000"))
             .verifyComplete()
@@ -420,7 +393,7 @@ class MathFluxExtensionsTests {
     fun sumBigIntegerInts() {
         intArrayOf(2_000_000_000, 2_000_000_000)
             .toFlux()
-            .sumBigInt()
+            .sumAsBigInt()
             .test()
             .expectNext(BigInteger("4000000000"))
             .verifyComplete()
@@ -430,7 +403,7 @@ class MathFluxExtensionsTests {
     fun sumBigIntegerLongs() {
         longArrayOf(30_000_000_000, 20_000_000_000)
             .toFlux()
-            .sumBigInt()
+            .sumAsBigInt()
             .test()
             .expectNext(BigInteger("50000000000"))
             .verifyComplete()
@@ -440,7 +413,7 @@ class MathFluxExtensionsTests {
     fun sumBigIntegerFloats() {
         floatArrayOf(3.9f, 1.9f)
             .toFlux()
-            .sumBigInt()
+            .sumAsBigInt()
             .test()
             .expectNext(BigInteger("4"))
             .verifyComplete()
@@ -450,18 +423,9 @@ class MathFluxExtensionsTests {
     fun sumBigIntegerDoubles() {
         doubleArrayOf(3.9, 1.9)
             .toFlux()
-            .sumBigInt()
+            .sumAsBigInt()
             .test()
             .expectNext(BigInteger("4"))
-            .verifyComplete()
-    }
-
-    @Test
-    fun sumBigIntegerMapped() {
-        userList.toFlux()
-            .sumBigInt { it.age }
-            .test()
-            .expectNext(BigInteger("99"))
             .verifyComplete()
     }
 
@@ -471,7 +435,7 @@ class MathFluxExtensionsTests {
     fun sumBigDecimalShorts() {
         shortArrayOf(32_000, 32_000)
             .toFlux()
-            .sumBigDecimal()
+            .sumAsBigDecimal()
             .test()
             .expectNext(BigDecimal("64000"))
             .verifyComplete()
@@ -481,7 +445,7 @@ class MathFluxExtensionsTests {
     fun sumBigDecimalInts() {
         intArrayOf(2_000_000_000, 2_000_000_000)
             .toFlux()
-            .sumBigDecimal()
+            .sumAsBigDecimal()
             .test()
             .expectNext(BigDecimal("4000000000"))
             .verifyComplete()
@@ -491,7 +455,7 @@ class MathFluxExtensionsTests {
     fun sumBigDecimalLongs() {
         longArrayOf(30_000_000_000, 20_000_000_000)
             .toFlux()
-            .sumBigDecimal()
+            .sumAsBigDecimal()
             .test()
             .expectNext(BigDecimal("50000000000"))
             .verifyComplete()
@@ -501,7 +465,7 @@ class MathFluxExtensionsTests {
     fun sumBigDecimalFloats() {
         floatArrayOf(3.5f, 1.99f)
             .toFlux()
-            .sumBigDecimal()
+            .sumAsBigDecimal()
             .test()
             .expectNext(BigDecimal("5.49"))
             .verifyComplete()
@@ -511,18 +475,9 @@ class MathFluxExtensionsTests {
     fun sumBigDecimalDoubles() {
         doubleArrayOf(3.5, 1.99)
             .toFlux()
-            .sumBigDecimal()
+            .sumAsBigDecimal()
             .test()
             .expectNext(BigDecimal("5.49"))
-            .verifyComplete()
-    }
-
-    @Test
-    fun sumBigDecimalMapped() {
-        userList.toFlux()
-            .sumBigDecimal { it.age }
-            .test()
-            .expectNext(BigDecimal("99"))
             .verifyComplete()
     }
 
@@ -532,7 +487,7 @@ class MathFluxExtensionsTests {
     fun averageJustShorts() {
         shortArrayOf(10, 11, 13, 14)
             .toFlux()
-            .averageJust()
+            .averageAll()
             .test()
             .expectNext(12)
             .verifyComplete()
@@ -542,7 +497,7 @@ class MathFluxExtensionsTests {
     fun averageJustInts() {
         intArrayOf(10, 11, 13, 14)
             .toFlux()
-            .averageJust()
+            .averageAll()
             .test()
             .expectNext(12)
             .verifyComplete()
@@ -552,7 +507,7 @@ class MathFluxExtensionsTests {
     fun averageJustLongs() {
         longArrayOf(10, 11, 13, 14)
             .toFlux()
-            .averageJust()
+            .averageAll()
             .test()
             .expectNext(12)
             .verifyComplete()
@@ -562,7 +517,7 @@ class MathFluxExtensionsTests {
     fun averageJustFloats() {
         floatArrayOf(10f, 11f)
             .toFlux()
-            .averageJust()
+            .averageAll()
             .test()
             .expectNext(10.5f)
             .verifyComplete()
@@ -572,7 +527,7 @@ class MathFluxExtensionsTests {
     fun averageJustDoubles() {
         doubleArrayOf(10.0, 11.0)
             .toFlux()
-            .averageJust()
+            .averageAll()
             .test()
             .expectNext(10.5)
             .verifyComplete()
@@ -581,7 +536,7 @@ class MathFluxExtensionsTests {
     @Test
     fun averageOfMapped() {
         userList.toFlux()
-            .averageOf { it.age }
+            .averageAll { it.age }
             .test()
             .expectNext(33)
             .verifyComplete()
@@ -654,7 +609,7 @@ class MathFluxExtensionsTests {
     fun averageFloatShorts() {
         shortArrayOf(10, 11)
             .toFlux()
-            .averageFloat()
+            .averageAsFloat()
             .test()
             .expectNext(10.5f)
             .verifyComplete()
@@ -664,7 +619,7 @@ class MathFluxExtensionsTests {
     fun averageFloatInts() {
         intArrayOf(10, 11)
             .toFlux()
-            .averageFloat()
+            .averageAsFloat()
             .test()
             .expectNext(10.5f)
             .verifyComplete()
@@ -674,7 +629,7 @@ class MathFluxExtensionsTests {
     fun averageFloatLongs() {
         longArrayOf(10, 11)
             .toFlux()
-            .averageFloat()
+            .averageAsFloat()
             .test()
             .expectNext(10.5f)
             .verifyComplete()
@@ -684,7 +639,7 @@ class MathFluxExtensionsTests {
     fun averageFloatFloats() {
         floatArrayOf(10f, 11f)
             .toFlux()
-            .averageFloat()
+            .averageAsFloat()
             .test()
             .expectNext(10.5f)
             .verifyComplete()
@@ -694,18 +649,9 @@ class MathFluxExtensionsTests {
     fun averageFloatDoubles() {
         doubleArrayOf(10.0, 11.0)
             .toFlux()
-            .averageFloat()
+            .averageAsFloat()
             .test()
             .expectNext(10.5f)
-            .verifyComplete()
-    }
-
-    @Test
-    fun averageFloatMapped() {
-        userList.toFlux()
-            .averageFloat { it.age }
-            .test()
-            .expectNext(33.0f)
             .verifyComplete()
     }
 
@@ -715,7 +661,7 @@ class MathFluxExtensionsTests {
     fun averageDoubleShorts() {
         shortArrayOf(10, 11)
             .toFlux()
-            .averageDouble()
+            .averageAsDouble()
             .test()
             .expectNext(10.5)
             .verifyComplete()
@@ -725,7 +671,7 @@ class MathFluxExtensionsTests {
     fun averageDoubleInts() {
         intArrayOf(10, 11)
             .toFlux()
-            .averageDouble()
+            .averageAsDouble()
             .test()
             .expectNext(10.5)
             .verifyComplete()
@@ -735,7 +681,7 @@ class MathFluxExtensionsTests {
     fun averageDoubleLongs() {
         longArrayOf(10, 11)
             .toFlux()
-            .averageDouble()
+            .averageAsDouble()
             .test()
             .expectNext(10.5)
             .verifyComplete()
@@ -745,7 +691,7 @@ class MathFluxExtensionsTests {
     fun averageDoubleFloats() {
         floatArrayOf(10f, 11f)
             .toFlux()
-            .averageDouble()
+            .averageAsDouble()
             .test()
             .expectNext(10.5)
             .verifyComplete()
@@ -755,18 +701,9 @@ class MathFluxExtensionsTests {
     fun averageDoubleDoubles() {
         doubleArrayOf(10.0, 11.0)
             .toFlux()
-            .averageDouble()
+            .averageAsDouble()
             .test()
             .expectNext(10.5)
-            .verifyComplete()
-    }
-
-    @Test
-    fun averageDoubleMapped() {
-        userList.toFlux()
-            .averageDouble { it.age }
-            .test()
-            .expectNext(33.0)
             .verifyComplete()
     }
 
@@ -776,7 +713,7 @@ class MathFluxExtensionsTests {
     fun averageBigIntShorts() {
         shortArrayOf(10, 11, 12)
             .toFlux()
-            .averageBigInt()
+            .averageAsBigInt()
             .test()
             .expectNext(BigInteger("11"))
             .verifyComplete()
@@ -786,7 +723,7 @@ class MathFluxExtensionsTests {
     fun averageBigIntInts() {
         intArrayOf(10, 11, 12)
             .toFlux()
-            .averageBigInt()
+            .averageAsBigInt()
             .test()
             .expectNext(BigInteger("11"))
             .verifyComplete()
@@ -796,7 +733,7 @@ class MathFluxExtensionsTests {
     fun averageBigIntLongs() {
         longArrayOf(10, 11, 12)
             .toFlux()
-            .averageBigInt()
+            .averageAsBigInt()
             .test()
             .expectNext(BigInteger("11"))
             .verifyComplete()
@@ -806,7 +743,7 @@ class MathFluxExtensionsTests {
     fun averageBigIntFloats() {
         floatArrayOf(10f, 11f, 12f)
             .toFlux()
-            .averageBigInt()
+            .averageAsBigInt()
             .test()
             .expectNext(BigInteger("11"))
             .verifyComplete()
@@ -816,18 +753,9 @@ class MathFluxExtensionsTests {
     fun averageBigIntDoubles() {
         doubleArrayOf(10.0, 11.0, 12.0)
             .toFlux()
-            .averageBigInt()
+            .averageAsBigInt()
             .test()
             .expectNext(BigInteger("11"))
-            .verifyComplete()
-    }
-
-    @Test
-    fun averageBigIntMapped() {
-        userList.toFlux()
-            .averageBigInt { it.age }
-            .test()
-            .expectNext(BigInteger("33"))
             .verifyComplete()
     }
 
@@ -837,7 +765,7 @@ class MathFluxExtensionsTests {
     fun averageBigDecimalShorts() {
         shortArrayOf(10, 11, 11, 11)
             .toFlux()
-            .averageBigDecimal()
+            .averageAsBigDecimal()
             .test()
             .expectNext(BigDecimal("10.75"))
             .verifyComplete()
@@ -847,7 +775,7 @@ class MathFluxExtensionsTests {
     fun averageBigDecimalInts() {
         intArrayOf(10, 11, 11, 11)
             .toFlux()
-            .averageBigDecimal()
+            .averageAsBigDecimal()
             .test()
             .expectNext(BigDecimal("10.75"))
             .verifyComplete()
@@ -857,7 +785,7 @@ class MathFluxExtensionsTests {
     fun averageBigDecimalLongs() {
         longArrayOf(10, 11, 11, 11)
             .toFlux()
-            .averageBigDecimal()
+            .averageAsBigDecimal()
             .test()
             .expectNext(BigDecimal("10.75"))
             .verifyComplete()
@@ -867,7 +795,7 @@ class MathFluxExtensionsTests {
     fun averageBigDecimalFloats() {
         floatArrayOf(10f, 11f, 12f, 13.5f)
             .toFlux()
-            .averageBigDecimal()
+            .averageAsBigDecimal()
             .test()
             .expectNext(BigDecimal("11.625"))
             .verifyComplete()
@@ -877,18 +805,9 @@ class MathFluxExtensionsTests {
     fun averageBigDecimalDoubles() {
         doubleArrayOf(10.0, 11.0, 12.0, 13.5)
             .toFlux()
-            .averageBigDecimal()
+            .averageAsBigDecimal()
             .test()
             .expectNext(BigDecimal("11.625"))
-            .verifyComplete()
-    }
-
-    @Test
-    fun averageBigDecimalMapped() {
-        userList.toFlux()
-            .averageBigDecimal { it.age }
-            .test()
-            .expectNext(BigDecimal("33"))
             .verifyComplete()
     }
 

--- a/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
@@ -40,6 +40,67 @@ class MathFluxExtensionsTests {
         val comparableList = listOf("AA", "A", "BB", "B", "AB")
     }
 
+    //== New sum Just and Of ==
+
+    @Test
+    fun sumJustShorts() {
+        shortArrayOf(15_000, 16_000)
+            .toFlux()
+            .sumJust()
+            .test()
+            .expectNext(31_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumJustInts() {
+        intArrayOf(200_000_000, 200_000_000)
+            .toFlux()
+            .sumJust()
+            .test()
+            .expectNext(400_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumJustLongs() {
+        longArrayOf(3_000_000_000, 2_000_000_000)
+            .toFlux()
+            .sumJust()
+            .test()
+            .expectNext(5_000_000_000)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumJustFloats() {
+        floatArrayOf(3.6f, 1.5f)
+            .toFlux()
+            .sumJust()
+            .test()
+            .expectNext(5.1f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumJustDoubles() {
+        doubleArrayOf(3.5, 1.6)
+            .toFlux()
+            .sumJust()
+            .test()
+            .expectNext(5.1)
+            .verifyComplete()
+    }
+
+    @Test
+    fun sumOfMapped() {
+        userList.toFlux()
+            .sumOf { it.age }
+            .test()
+            .expectNext(99)
+            .verifyComplete()
+    }
+
     //== sum ==
     @Test
     fun sumShorts() {
@@ -462,6 +523,67 @@ class MathFluxExtensionsTests {
             .sumBigDecimal { it.age }
             .test()
             .expectNext(BigDecimal("99"))
+            .verifyComplete()
+    }
+
+    //== New average Just and Of ==
+
+    @Test
+    fun averageJustShorts() {
+        shortArrayOf(10, 11, 13, 14)
+            .toFlux()
+            .averageJust()
+            .test()
+            .expectNext(12)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageJustInts() {
+        intArrayOf(10, 11, 13, 14)
+            .toFlux()
+            .averageJust()
+            .test()
+            .expectNext(12)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageJustLongs() {
+        longArrayOf(10, 11, 13, 14)
+            .toFlux()
+            .averageJust()
+            .test()
+            .expectNext(12)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageJustFloats() {
+        floatArrayOf(10f, 11f)
+            .toFlux()
+            .averageJust()
+            .test()
+            .expectNext(10.5f)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageJustDoubles() {
+        doubleArrayOf(10.0, 11.0)
+            .toFlux()
+            .averageJust()
+            .test()
+            .expectNext(10.5)
+            .verifyComplete()
+    }
+
+    @Test
+    fun averageOfMapped() {
+        userList.toFlux()
+            .averageOf { it.age }
+            .test()
+            .expectNext(33)
             .verifyComplete()
     }
 


### PR DESCRIPTION
fix #28 

Added missing Kotlin wrappers for all sum() and average() methods provided in reactor.math.MathFlux to the library

 - Added unit test to cover all of these methods using the existing unit tests as a guide
 - Include Java Doc for all new methods with @ since based on the current snapshot version. 
 - Note Inconsistency, since the existing methods have @ since based on reactor-extra version numbering. 