### PR TITLE
Deprecate extensions for RxJava2, Repeat and Retry

### DIFF
--- a/src/main/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExt.kt
+++ b/src/main/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExt.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 VMware Inc. or its affiliates, All Rights Reserved.
+ * Copyright (c) 2011-2022 VMware Inc. or its affiliates, All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,10 @@ import reactor.core.publisher.Mono
  * properties of the Flowable through.
  * @param <T> the value type
  * @return the new Flux instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Flowable<T>.toFlux(): Flux<T> {
     return RxJava2Adapter.flowableToFlux<T>(this)
 }
@@ -37,7 +40,10 @@ fun <T> Flowable<T>.toFlux(): Flux<T> {
  * properties of the Flux through.
  * @param <T> the value type
  * @return the new Flux instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Flux<T>.toFlowable(): Flowable<T> {
     return RxJava2Adapter.fluxToFlowable(this)
 }
@@ -47,7 +53,10 @@ fun <T> Flux<T>.toFlowable(): Flowable<T> {
  * properties of the Flux through.
  * @param <T> the value type
  * @return the new Flux instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Mono<T>.toFlowable(): Flowable<T> {
     return RxJava2Adapter.monoToFlowable<T>(this)
 }
@@ -55,7 +64,10 @@ fun <T> Mono<T>.toFlowable(): Flowable<T> {
 /**
  * Wraps a void-Mono instance into a RxJava Completable.
  * @return the new Completable instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun Mono<*>.toCompletable(): Completable {
     return RxJava2Adapter.monoToCompletable(this)
 }
@@ -63,7 +75,10 @@ fun Mono<*>.toCompletable(): Completable {
 /**
  * Wraps a RxJava Completable into a Mono instance.
  * @return the new Mono instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun Completable.toMono(): Mono<Void> {
     return RxJava2Adapter.completableToMono(this)
 }
@@ -75,7 +90,10 @@ fun Completable.toMono(): Mono<Void> {
  * [NoSuchElementException].
  * @param <T> the value type
  * @return the new Single instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Mono<T>.toSingle(): Single<T> {
     return RxJava2Adapter.monoToSingle(this)
 }
@@ -84,7 +102,10 @@ fun <T> Mono<T>.toSingle(): Single<T> {
  * Wraps a RxJava Single into a Mono instance.
  * @param <T> the value type
  * @return the new Mono instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Single<T>.toMono(): Mono<T> {
     return RxJava2Adapter.singleToMono<T>(this)
 }
@@ -94,7 +115,10 @@ fun <T> Single<T>.toMono(): Mono<T> {
  * @param <T> the value type
  * @param strategy the back-pressure strategy, default is BUFFER
  * @return the new Flux instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Observable<T>.toFlux(strategy: BackpressureStrategy = BackpressureStrategy.BUFFER): Flux<T> {
     return RxJava2Adapter.observableToFlux(this, strategy)
 }
@@ -103,7 +127,10 @@ fun <T> Observable<T>.toFlux(strategy: BackpressureStrategy = BackpressureStrate
  * Wraps a Flux instance into a RxJava Observable.
  * @param <T> the value type
  * @return the new Observable instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Flux<T>.toObservable(): Observable<T> {
     return RxJava2Adapter.fluxToFlowable(this).toObservable()
 }
@@ -112,7 +139,10 @@ fun <T> Flux<T>.toObservable(): Observable<T> {
  * Wraps an RxJava Maybe into a Mono instance.
  * @param <T> the value type
  * @return the new Mono instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Maybe<T>.toMono(): Mono<T> {
     return RxJava2Adapter.maybeToMono(this)
 }
@@ -121,7 +151,10 @@ fun <T> Maybe<T>.toMono(): Mono<T> {
  * WRaps Mono instance into an RxJava Maybe.
  * @param <T> the value type
  * @return the new Maybe instance
+ * @deprecated RxJava adapters are being removed from the scope of extensions.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "RxJava adapters are being removed from the scope of extensions.")
 fun <T> Mono<T>.toMaybe(): Maybe<T> {
     return RxJava2Adapter.monoToMaybe(this)
 }

--- a/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
@@ -37,7 +37,9 @@ import java.util.function.Consumer
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
 fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -63,7 +65,9 @@ fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
 fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)
@@ -89,7 +93,9 @@ fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration?
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
 fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -115,7 +121,9 @@ fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
 fun <T> Mono<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)

--- a/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
@@ -37,7 +37,10 @@ import java.util.function.Consumer
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
 fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
@@ -64,7 +67,10 @@ fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
 fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
     val retry = Retry.any<T>()
@@ -90,7 +96,10 @@ fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? 
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
 fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
@@ -117,7 +126,10 @@ fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  *
  * @author Simon Baslé
  * @since 3.1.1
+ * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
+ * To be removed at the earliest in 1.3.0.
  */
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
 fun <T> Mono<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
     val retry = Retry.any<T>()


### PR DESCRIPTION
This PR marks RxJava2Adapter, Retry and Repeat extensions as deprecated, to be
removed in 1.3.0 at the earliest.

This removal will probably occur at the earliest in order to remove dependencies
to external libraries and to soon-to-be-deleted addons.

Fixes #31.