### PR TITLE
Adapt to addons sumBigInteger changes, upgrade Reactor

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-reactorCore = "3.4.17-SNAPSHOT"
-reactorAddons = "3.4.8-SNAPSHOT"
+reactorCore = "3.4.20-SNAPSHOT"
+reactorAddons = "3.4.9-SNAPSHOT"
 # Other shared versions
 kotlin = "1.5.32"
 swt = "4.5.2"

--- a/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/extra/math/MathFluxExtensionsTests.kt
@@ -478,7 +478,8 @@ class MathFluxExtensionsTests {
             .toFlux()
             .sumAsBigInt()
             .test()
-            .expectNext(BigInteger("4"))
+            // 5.8 which now gets rounded down to 5 as sum drops the fractional part
+            .expectNext(BigInteger("5"))
             .verifyComplete()
     }
 
@@ -488,7 +489,8 @@ class MathFluxExtensionsTests {
             .toFlux()
             .sumAsBigInt()
             .test()
-            .expectNext(BigInteger("4"))
+            // == 5.8 which now gets rounded down to 5 as sum drops the fractional part
+            .expectNext(BigInteger("5"))
             .verifyComplete()
     }
 


### PR DESCRIPTION
This commit adapts to changes in precision in addons' sumBigInteger that
were introduced in the previously referenced snapshot (3.4.8).

It also upgrades the dependency to reflect the latest core and addons
snapshots, as the project was previously out of sync.

For the change in sumBigInteger, see reactor/reactor-addons#286:

Now the loss of precision is only triggered at the end of the sum,
avoiding lossy conversion of each floating point number that is being
summed.
