### PR TITLE
Upgrade to Kotlin 1.7, Dokka 1.6.21 for now

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 reactorCore = "3.5.0-SNAPSHOT"
 reactorAddons = "3.5.0-SNAPSHOT"
 # Other shared versions
-kotlin = "1.5.32"
+kotlin = "1.7.0"
 
 [libraries]
 reactor-core = { module = "io.projectreactor:reactor-core", version.ref = "reactorCore" }
@@ -18,4 +18,4 @@ rxJava2 = "io.reactivex.rxjava2:rxjava:2.2.8"
 [plugins]
 artifactory = { id = "com.jfrog.artifactory", version = "4.27.1" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.5.31" }
+kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.6.21" }


### PR DESCRIPTION

The new Kotlin baseline in 1.2 is going to be Kotlin 1.7.

This is following the steps of Spring Framework 6 and Spring Boot 3,
which will be the main adoption drivers for this line.

As of now, no new version of the Dokka tool has been released that
matches the new Kotlin. It will be updated in a follow-up PR once
available.

Fixes #45.