### PR TITLE
Dokka now also at v1.7

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,4 +18,4 @@ rxJava2 = "io.reactivex.rxjava2:rxjava:2.2.8"
 [plugins]
 artifactory = { id = "com.jfrog.artifactory", version = "4.27.1" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.6.21" }
+kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.7.0" }


### PR DESCRIPTION
Follow-up to #49, aligning with the Kotlin version.