### PR TITLE
release hotfix: Adapt to MonoSubscriber not fusing by default

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-reactorCore = "3.4.22-SNAPSHOT"
+reactorCore = "3.4.24-SNAPSHOT"
 reactorAddons = "3.4.9-SNAPSHOT"
 # Other shared versions
 kotlin = "1.5.32"

--- a/src/test/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExtTest.kt
+++ b/src/test/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExtTest.kt
@@ -97,16 +97,17 @@ class RxJava2AdapterExtTest {
                 .assertNotComplete()
     }
 
-    @Test
-    fun `Single to Mono`() {
-        Single.just(1)
-                .toMono()
-                .test()
-                .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-                .expectNext(1)
-                .expectComplete()
-                .verify()
-    }
+// FIXME
+//    @Test
+//    fun `Single to Mono`() {
+//        Single.just(1)
+//                .toMono()
+//                .test()
+//                .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
+//                .expectNext(1)
+//                .expectComplete()
+//                .verify()
+//    }
 
     @Test
     fun `Observable to Flux`() {

--- a/src/test/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExtTest.kt
+++ b/src/test/kotlin/reactor/kotlin/adapter/rxjava/RxJava2AdapterExtTest.kt
@@ -98,16 +98,16 @@ class RxJava2AdapterExtTest {
     }
 
 // FIXME
-//    @Test
-//    fun `Single to Mono`() {
-//        Single.just(1)
-//                .toMono()
-//                .test()
+    @Test
+    fun `Single to Mono`() {
+        Single.just(1)
+                .toMono()
+                .test()
 //                .expectFusion(Fuseable.ANY, Fuseable.ASYNC)
-//                .expectNext(1)
-//                .expectComplete()
-//                .verify()
-//    }
+                .expectNext(1)
+                .expectComplete()
+                .verify()
+    }
 
     @Test
     fun `Observable to Flux`() {


### PR DESCRIPTION
In reactor-core, `Operators.MonoSubscriber` has stopped implementing ASYNC fusion as a base. It continues to be compatible with Fuseable publishers but now by default only negotiates `Fuseable.NONE`.

Some RxJava adapter classes don't really have a way of propagating the fusion up to RxJava and used to rely on the default ASYNC capability of MonoSubscriber, testing that `requestFusion` would indeed negotiate that. Now that it negotiates NONE, said tests fail.

This commit removes the tests and adds a FIXME as a more in depth follow up to this issue (where we can evaluate if it makes sense to keep the publishers Fuseable).

Also update to latest 3.4.x core snapshot.

See reactor/reactor-core#3245.