### PR TITLE
Add Flux collectMap of Pairs extension

### DIFF
--- a/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/core/publisher/FluxExtensions.kt
@@ -18,6 +18,7 @@ package reactor.kotlin.core.publisher
 
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.stream.Stream
 import kotlin.reflect.KClass
 
@@ -225,3 +226,11 @@ fun <T> Flux<T>.switchIfEmpty(s: () -> Publisher<T>): Flux<T> = this.switchIfEmp
  * @since 1.1.3
  */
 fun <T> Flux<T>.switchIfEmptyDeferred(s: () -> Publisher<T>): Flux<T> = this.switchIfEmpty(Flux.defer { s() })
+
+/**
+ * Extension for [Flux.collectMap] to collect Kotlin [Pair]s into a [Map]
+ *
+ * @author Aram Messdaghi
+ * @since 1.1.9
+ */
+fun <K, V> Flux<Pair<K, V>>.collectMap(): Mono<Map<K, V>> = collectMap(Pair<K, V>::first, Pair<K, V>::second)

--- a/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
+++ b/src/test/kotlin/reactor/kotlin/core/publisher/FluxExtensionsTests.kt
@@ -251,4 +251,15 @@ class FluxExtensionsTests {
             .expectError<RuntimeException>()
             .verify()
     }
+
+    @Test
+    fun `collectMap with pairs`() {
+        val inputPairs: List<Pair<String, Int>> = listOf("a" to 1, "b" to 2, "c" to 3)
+        val collectedMap: Mono<Map<String, Int>> = inputPairs.toFlux()
+            .collectMap()
+
+        collectedMap.test()
+            .expectNext(inputPairs.toMap())
+            .verifyComplete()
+    }
 }


### PR DESCRIPTION
This commit adds an extension function to Flux<Pair<K,V>> to collect it to a Mono<Map<K,V>>
Fixes #54 