### PR TITLE
Improve javadoc of deprecated repeat and retry extensions

### DIFF
--- a/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
@@ -37,9 +37,13 @@ import java.util.function.Consumer
  *
  * @author Simon Baslé
  * @since 3.1.1
- * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
+ * @deprecated Reactor-Extra repeat features are being phased out. If you still
+ *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
+@Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
+        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "runtime dependency is needed.")
 fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -65,9 +69,13 @@ fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  *
  * @author Simon Baslé
  * @since 3.1.1
- * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
+ * @deprecated Reactor-Extra repeat features are being phased out. If you still
+ *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
+@Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
+        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "runtime dependency is needed.")
 fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)
@@ -93,9 +101,13 @@ fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration?
  *
  * @author Simon Baslé
  * @since 3.1.1
- * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
+ * @deprecated Reactor-Extra repeat features are being phased out. If you still
+ *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
+@Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
+        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "runtime dependency is needed.")
 fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
                                          doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -121,9 +133,13 @@ fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  *
  * @author Simon Baslé
  * @since 3.1.1
- * @deprecated Reactor-Extra repeat features are being phased out. To be removed at the earliest in 1.3.0.
+ * @deprecated Reactor-Extra repeat features are being phased out. If you still
+ *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra repeat features are being phased out.")
+@Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
+        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "runtime dependency is needed.")
 fun <T> Mono<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
     val repeat = Repeat.times<T>(times)

--- a/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RepeatExtensions.kt
@@ -38,11 +38,11 @@ import java.util.function.Consumer
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra repeat features are being phased out. If you still
- *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
-        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "If you still need to call this method, io.projectreactor:reactor-extras " +
         "runtime dependency is needed.")
 fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
@@ -70,11 +70,11 @@ fun <T> Flux<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra repeat features are being phased out. If you still
- *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
-        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "If you still need to call this method, io.projectreactor:reactor-extras " +
         "runtime dependency is needed.")
 fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {
@@ -102,11 +102,11 @@ fun <T> Flux<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration?
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra repeat features are being phased out. If you still
- *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
-        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "If you still need to call this method, io.projectreactor:reactor-extras " +
         "runtime dependency is needed.")
 fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                          jitter: Boolean = false,
@@ -134,11 +134,11 @@ fun <T> Mono<T>.repeatExponentialBackoff(times: Long, first: Duration, max: Dura
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra repeat features are being phased out. If you still
- *   need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra repeat features are being phased out. " +
-        "If you still need to call it, io.projectreactor:reactor-extras " +
+        "If you still need to call this method, io.projectreactor:reactor-extras " +
         "runtime dependency is needed.")
 fun <T> Mono<T>.repeatRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                     doOnRepeat: ((RepeatContext<T>) -> Unit)? = null): Flux<T> {

--- a/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
@@ -38,9 +38,11 @@ import java.util.function.Consumer
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- * To be removed at the earliest in 1.3.0.
+ *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
+        "If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.")
 fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
@@ -68,9 +70,11 @@ fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- * To be removed at the earliest in 1.3.0.
+ *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
+        "If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.")
 fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Flux<T> {
     val retry = Retry.any<T>()
@@ -97,9 +101,11 @@ fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? 
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- * To be removed at the earliest in 1.3.0.
+ *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
+        "If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.")
 fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Duration? = null,
                                         jitter: Boolean = false,
                                         doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
@@ -127,9 +133,11 @@ fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- * To be removed at the earliest in 1.3.0.
+ *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   To be removed at the earliest in 1.3.0.
  */
-@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed.")
+@Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
+        "If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.")
 fun <T> Mono<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? = null,
                                    doOnRetry: ((RetryContext<T>) -> Unit)? = null): Mono<T> {
     val retry = Retry.any<T>()

--- a/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
+++ b/src/main/kotlin/reactor/kotlin/extra/retry/RetryExtensions.kt
@@ -38,7 +38,7 @@ import java.util.function.Consumer
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
@@ -70,7 +70,7 @@ fun <T> Flux<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
@@ -101,7 +101,7 @@ fun <T> Flux<T>.retryRandomBackoff(times: Long, first: Duration, max: Duration? 
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +
@@ -133,7 +133,7 @@ fun <T> Mono<T>.retryExponentialBackoff(times: Long, first: Duration, max: Durat
  * @author Simon Baslé
  * @since 3.1.1
  * @deprecated Reactor-Extra retry features have been replaced by a core alternative and will be removed.
- *   If you still need to call it, io.projectreactor:reactor-extras runtime dependency is needed.
+ *   If you still need to call this method, io.projectreactor:reactor-extras runtime dependency is needed.
  *   To be removed at the earliest in 1.3.0.
  */
 @Deprecated(message = "Reactor-Extra retry features have been replaced by a core alternative and will be removed. " +


### PR DESCRIPTION
This change adds information about the required runtime dependency of reactor-extras for the deprecated extension methods for repeat and retry operations.